### PR TITLE
Update link to changelog

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@ description: An organizer for your porn
 			<h2>Upcoming features</h2>
 			<p>
 				View the changelog for the development build 
-				<a href="https://github.com/stashapp/stash/blob/develop/ui/v2.5/src/components/Changelog/versions" target="_blank">here</a>.
+				<a href="https://github.com/stashapp/stash/blob/master/ui/v2.5/src/docs/en/Changelog" target="_blank">here</a>.
 			</p>
 		</div>
 	</section>


### PR DESCRIPTION
The old link seems to no longer be valid. Updating to a new link

I asked about this on the Discord and was pointed to this new URL as the correct one to link to.